### PR TITLE
Move criterion to the dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
 criterion = "0.3.3"
 
 [[bench]]


### PR DESCRIPTION
Move critertion to the dev deps so we don't have to build it when using horrid-vec as a library.﻿